### PR TITLE
Fixed defaultPackage for newer nix flake versions.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,10 +103,7 @@
           };
 
           defaultPackage = packages.cq-editor;
-          defaultApp = {
-            type = "app";
-            program = defaultPackage + "/bin/cq-editor";
-          };
+          apps.default = flake-utils.lib.mkApp { drv = defaultPackage; }; 
           overlays = { inherit py-overrides; };
           # TODO: add dev env for cadquery
           # devShell = packages.cadquery-dev-shell;


### PR DESCRIPTION
See https://github.com/NixOS/nix/issues/6448

Currently this flake errors for me (on a very recent nixpkgs master). With this error:

```
error: attribute 'defaultApp.x86_64-linux' should have type 'derivation'
```