### PR TITLE
feat(cachix): add cachix substituter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,11 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [ "https://marcus7070.cachix.org" ];
+    extra-trusted-public-keys = [ "marcus7070.cachix.org-1:JawxHSgnYsgNYJmNqZwvLjI4NcOwrcEZDToWlT3WwXw=" ];
+  };
+
   outputs = { self, nixpkgs, flake-utils, ... } @ inputs:
     let
       # someone else who can do the testing might want to extend this to other systems


### PR DESCRIPTION
This change adds `nixConfig` as a flake output. When running flake commands like `nix run ` it will allow to use the cachix cache.