### PR TITLE
Export python package overlay

### DIFF
--- a/expressions/py-overrides.nix
+++ b/expressions/py-overrides.nix
@@ -1,29 +1,33 @@
 {
-  llvmPackages
-  , pywrap-src
+  pywrap-src
   , ocp-src
   , ocp-stubs-src
   , cadquery-src
-  , occt
-  , fetchFromGitHub
-  , casadi
   , pybind11-stubgen-src
-  , lib3mf
-}: self: super: rec {
+}: self: super: {
+
+  # NOTE(vinszent): Latest dev env uses LLVM 15 (https://github.com/CadQuery/OCP/blob/master/environment.devenv.yml)
+
+  cqLlvmPackages = self.pkgs.llvmPackages_15;
+
+  opencascade-occt = self.callPackage ./opencascade-occt { };
+
+  casadi = super.casadi.override {
+    pythonSupport = true;
+  };
 
   clang = self.callPackage ./clang.nix {
-    inherit llvmPackages;
+    llvmPackages = self.cqLlvmPackages;
   };
 
   pywrap = self.callPackage ./pywrap {
-    inherit llvmPackages;
+    llvmPackages = self.cqLlvmPackages;
     src = pywrap-src;
   };
 
   ocp = self.callPackage ./OCP {
-    llvmPackages = llvmPackages;
+    llvmPackages = self.cqLlvmPackages;
     src = ocp-src;
-    opencascade-occt = occt;
   };
 
   ocp-stubs = self.callPackage ./OCP/stubs.nix {
@@ -54,7 +58,11 @@
 
   ocpsvg = self.callPackage ./ocpsvg.nix {};
 
-  py-lib3mf = self.callPackage ./py-lib3mf.nix {inherit lib3mf;};
+  lib3mf = self.callPackage ./lib3mf.nix {};
+
+  py-lib3mf = self.callPackage ./py-lib3mf.nix {
+    inherit (self) lib3mf;
+  };
 
   trianglesolver = self.callPackage ./trianglesolver.nix {};
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,22 +52,15 @@
             buildFlags = ["scotch ptscotch esmumps ptesmumps"];
             installFlags = ["prefix=\${out} scotch ptscotch esmumps ptesmumps" ];
           } );
-          opencascade-occt = pkgs.callPackage ./expressions/opencascade-occt { };
-          lib3mf-231 = pkgs.callPackage ./expressions/lib3mf.nix {};
-          py-overrides = import expressions/py-overrides.nix {
+          py-overrides = import ./expressions/py-overrides.nix {
             inherit (inputs) pywrap-src ocp-src ocp-stubs-src cadquery-src pybind11-stubgen-src;
-            inherit (pkgs) fetchFromGitHub;
-            # NOTE(vinszent): Latest dev env uses LLVM 15 (https://github.com/CadQuery/OCP/blob/master/environment.devenv.yml)
-            llvmPackages = pkgs.llvmPackages_15;
-            occt = opencascade-occt;
-            casadi = pkgs.casadi.override { pythonSupport=true; };
-            lib3mf = lib3mf-231;
           };
           python = pkgs.python311.override {
             packageOverrides = py-overrides;
             self = python;
           };
         in rec {
+          lib.pythonPackageOverrides = py-overrides;
           packages = {
             inherit (python.pkgs) cadquery cq-kit cq-warehouse build123d;
             inherit python;


### PR DESCRIPTION
**NOTE**: Superseded by #57 which has a better approach.

---

Hey there,

Thanks for making cadquery possible on NixOS. In my case I already had my own python package overrides so I needed to export the `packageOverrides` option and combine them like so:

```nix
  python3 = prev.python3.override {
    packageOverrides = final.lib.composeManyExtensions [
      inputs.cq-flake.lib.${final.system}.pythonPackageOverrides
      (final.callPackage ./python-overrides.nix { })
    ];
  };
```

I also tidied up the overrides overlay so it doesn't depend on cq-flake's nixpkgs input, only the `self` and `super` arguments.

Let me know if want anything changed.