### PR TITLE
Update packages and build on newer  `nixpkgs`

### DIFF
--- a/expressions/OCP/CMakeLists.txt
+++ b/expressions/OCP/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required( VERSION 3.17 )
+project( OCP )
+
+set( N_PROC 2 CACHE STRING "Number of processes used for generating code")
+
+
+find_package( LLVM REQUIRED )
+find_package( VTK REQUIRED
+  COMPONENTS
+    CommonCore
+    WrappingPythonCore
+    RenderingCore
+    RenderingOpenGL2
+    CommonDataModel
+    CommonExecutionModel
+    freetype
+)
+message(STATUS "VTK ${VTK_VERSION} found")
+find_package( RapidJSON REQUIRED )
+find_package( Clang REQUIRED )
+
+set( Python_FIND_VIRTUALENV FIRST )
+find_package( Python 3.9 COMPONENTS Interpreter Development REQUIRED )
+
+# find OCCT and dump symbols
+find_package( OpenCASCADE REQUIRED )
+
+foreach(target ${OpenCASCADE_LIBRARIES} )
+    get_target_property(loc ${target} IMPORTED_LOCATION_RELEASE)
+    list( APPEND occt_libs ${loc} )
+endforeach()
+
+execute_process(
+    COMMAND
+    ${Python_EXECUTABLE}
+    dump_symbols.py
+    "${occt_libs}"
+    )
+
+
+get_target_property( LIBCLANG_PATH libclang IMPORTED_LOCATION_RELEASE )
+
+message( STATUS "Include dirs: ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}")
+
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    foreach( inc IN LISTS CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+        list( APPEND CXX_INCLUDES -i ${inc}/ )
+    endforeach()
+else()
+    list( APPEND CXX_INCLUDES -i /opt/usr/local/include/c++/v1/ -i /opt/usr/local/include/ )
+endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    set(PLATFORM Windows)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set(PLATFORM OSX)
+else()
+    set(PLATFORM Linux)
+endif()
+
+set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/pywrap )
+
+if( NOT EXISTS ${CMAKE_SOURCE_DIR}/OCP )
+    message( STATUS "Running pywrap")
+    execute_process(
+        COMMAND
+            ${Python_EXECUTABLE}
+            -m bindgen
+            -n $ENV{NIX_BUILD_CORES}
+            -l ${LIBCLANG_PATH}
+            -i ${CLANG_INCLUDE_DIRS}/
+            -i ${VTK_INCLUDE_DIR}/
+            -i ${CLANG_INSTALL_PREFIX}/lib/clang/${LLVM_VERSION}/include/
+            ${CXX_INCLUDES}
+            all ocp.toml ${PLATFORM}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMAND_ECHO STDOUT
+        RESULT_VARIABLE PYWRAP_RESULT
+    )
+
+    if( ${PYWRAP_RESULT} GREATER 0)
+        message(FATAL_ERROR "Pywrap call failed")
+    endif()
+
+endif()
+
+add_subdirectory( ${CMAKE_SOURCE_DIR}/OCP )

--- a/expressions/OCP/default.nix
+++ b/expressions/OCP/default.nix
@@ -1,5 +1,6 @@
 { lib
   , stdenv
+  , clangStdenv
   , src
   , buildPythonPackage
   , pythonOlder
@@ -11,13 +12,20 @@
   , pybind11
   , libglvnd
   , xorg
+  , freetype
   , python
   , writeTextFile
   , pywrap
-  , vtk
+  , utf8cpp
   , rapidjson
+  , nlohmann_json
   , lief
   , path
+  , setuptools
+
+  , vtk
+  , tbb_2021
+  , fontconfig
 }:
 let
   # We need to use an unmodified version number for the dist-utils version so
@@ -62,74 +70,87 @@ let
 
 
   # intermediate step, do pybind, cmake in the next step
-  ocp-pybound = stdenv.mkDerivation rec {
+  # llvmPackages.stdenv
+  ocp-pybound = llvmPackages.stdenv.mkDerivation rec {
     pname = "pybound-ocp";
     inherit version src;
 
+    /*
     phases = [
       "unpackPhase"
       "patchPhase"
       "buildPhase"
       "installPhase"
-    ];
+    ];*/
 
     nativeBuildInputs = [
+      # cmake
       pywrap
       rapidjson
+      nlohmann_json
       ocp-dump-symbols
+    ] ++ (with llvmPackages; [
+      libllvm
+      libclang
+    ]);
+
+    buildInputs = [
+      freetype
+      libglvnd
+      llvmPackages.openmp
+      tbb_2021
+      utf8cpp
+      xorg.xorgproto
+      xorg.libX11
     ];
+
+    dontWrapQtApps = true;
 
     postPatch = ''
       cp ${ocp-dump-symbols}/symbols_mangled_linux.dat ./
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "\''${CMAKE_SOURCE_DIR}/pywrap" \
+        "${python.pkgs.makePythonPath [ pywrap ]}" \
+        --replace-fail "\''${VTK_INCLUDE_DIR}" \
+        "${vtk}/include/vtk" \
+        --replace-fail "\''${N_PROC}" \
+        "\$ENV{NIX_BUILD_CORES}" \
+        --replace-fail "\''${CLANG_INSTALL_PREFIX}" \
+        "${llvmPackages.libclang.lib}" \
+        --replace-fail "add_subdirectory( \''${CMAKE_SOURCE_DIR}/OCP )" \
+        ""
     '';
+    # env.PYBIND11_USE_CMAKE = 1;
 
-    # should this actually be in pywrap?
-    preBuild = ''
-      export PYBIND11_USE_CMAKE=1
-    '';
+    cmakeFlags = with llvmPackages; [
+      "-GNinja"
+      "-DVTK_DIR=${vtk}/lib/cmake/vtk"
+      "-DOpenCASCADE_DIR=${opencascade-occt}/lib/cmake/opencascade"
+      "-Dpybind11_DIR=${pybind11}/share/cmake/pybind11"
 
-  # the order of the following includes is critical, but makes utterly zero sense to me. Order discovered by trial and error and hulk smashing the keyboard.
-    pywrapFlags = 
-    let
-      system = stdenv.hostPlatform.system;
-      compiler = if system == "x86_64-linux" then "x86_64-unknown-linux-gnu"
-                 else if system == "aarch64-linux" then "aarch64-unknown-linux-gnu"
-                 else (throw "unsupported system ${system}");
+      "-DCMAKE_C_COMPILER=${clang}/bin/clang"
+      "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
+    ];
 
-    in builtins.concatStringsSep " " (
-      map (p: ''-i '' + p) [
-        "${rapidjson}/include"
-        "${vtk}/include/vtk/"
-        "${xorg.xorgproto}/include"
-        "${xorg.libX11.dev}/include"
-        "${libglvnd.dev}/include"
-        "${stdenv.cc.cc}/include/c++/${stdenv.cc.version}"
-        "${stdenv.cc.cc}/include/c++/${stdenv.cc.version}/${compiler}"
-        "${glibc.dev}/include"
-        # gcc-14-20241116 has its include files in lib/gcc/x86_64-unknown-linux-gnu/14.2.1/
-        "${stdenv.cc.cc}/lib/gcc/${compiler}/*/include-fixed"
-        "${stdenv.cc.cc}/lib/gcc/${compiler}/*/include"
-    ]);
-
-    buildPhase = ''
-      runHook preBuild
-      pywrap -n $NIX_BUILD_CORES ${pywrapFlags} all ocp.toml
-      runHook postBuild
-    '';
+    dontBuild = true;
 
     installPhase = ''
       mkdir -p $out
-      cp -r ./* $out/
+      cd ..
+      cp -r ./OCP/* $out/
     '';
   };
 
-  ocp-result = stdenv.mkDerivation rec {
+  # llvmPackages.stdenv
+  ocp-result = llvmPackages.stdenv.mkDerivation rec {
     pname = "ocp-result";
     inherit version;
 
     src = ocp-pybound;
 
     disabled = pythonOlder "3.6";
+
+    # env.NIX_DEBUG = "1";
 
     # do not put glibc.dev in here https://discourse.nixos.org/t/how-to-get-this-basic-c-build-to-work-in-a-nix-shell/12262/3
     # https://github.com/NixOS/nixpkgs/pull/28748
@@ -139,23 +160,43 @@ let
       pywrap
       pybind11
       python
-      rapidjson
-    ];
+    ] /*++ (with llvmPackages; [
+      libllvm
+      libclang
+    ])*/;
 
     buildInputs = [
+      rapidjson
       libglvnd.dev
       xorg.libX11.dev
       xorg.xorgproto
       vtk
-    ] ++ opencascade-occt.buildInputs ++ vtk.buildInputs;
+      tbb_2021
+
+      # > The link interface of target "VTK::CommonCore" contains:
+      # >
+      # > OpenMP::OpenMP_CXX
+      llvmPackages.openmp
+      fontconfig
+    ];
+
+    /*
+    postPatch = ''
+      substituteInPlace OCP/CMakeLists.txt \
+        --replace-fail \
+        "include_directories( \''${PROJECT_SOURCE_DIR}" \
+        "include_directories( \''${PROJECT_SOURCE_DIR} \''${OpenCASCADE_VENDORED_INCLUDE_DIR}"
+    '';*/
+
+    env = {
+      PYBIND11_USE_CMAKE = 1;
+      CMAKE_PREFIX_PATH = "${pybind11}/share/cmake/pybind11:\${CMAKE_PREFIX_PATH}:${glibc.dev}/include";
+      NIX_CFLAGS_COMPILE = "-Wno-deprecated-declarations";
+    };
 
     preConfigure = ''
-      export CMAKE_PREFIX_PATH=${pybind11}/share/cmake/pybind11:$CMAKE_PREFIX_PATH
-      export PYBIND11_USE_CMAKE=1
-      export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:${glibc.dev}/include
       echo "CMAKE_INCLUDE_PATH is:"
       echo $CMAKE_INCLUDE_PATH
-      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-deprecated-declarations"
       echo "NIX_CFLAGS_COMPILE: $NIX_CFLAGS_COMPILE"
     '';
 
@@ -166,15 +207,20 @@ let
       opencascade-occt
     ];
 
-    cmakeFlags = [
-      "-S ../OCP"
+    cmakeFlags = with llvmPackages; [
       "-DPYTHON_EXECUTABLE=${python}/bin/python"
-      "-DOpenCASCADE_INCLUDE_DIR=${src}/opencascade"
       "-DVTK_DIR=${vtk}/lib/cmake/vtk/"
+      # "-DOpenCASCADE_VENDORED_INCLUDE_DIR=${src}/opencascade"
       "-Wno-dev"
+
+      /*
+      "-DCMAKE_C_COMPILER=${clang}/bin/clang"
+      "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"*/
     ];
 
-    seperateDebugInfo = true;
+    separateDebugInfo = true;
+    # vtk uses qtbase so we're forced to specify wrapping behavior
+    dontWrapQtApps = true;
 
     checkPhase = ''
       pushd .
@@ -224,6 +270,8 @@ in buildPythonPackage {
   pname = "OCP";
   inherit version;
   src = ocp-result;
+  pyproject = true;
+  build-system = [ setuptools ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION="${base-version}";
 

--- a/expressions/bd-warehouse.nix
+++ b/expressions/bd-warehouse.nix
@@ -1,0 +1,28 @@
+{
+  lib
+  , python
+  , buildPythonPackage
+  , fetchFromGitHub
+  , setuptools
+  , setuptools-scm
+  , build123d
+  , pytestCheckHook
+}:
+buildPythonPackage rec {
+  pname = "bd_warehouse";
+  rev = "97112a02d9538d57740a005a7802dd149d797568";
+  version = "0.0dev";
+  src = fetchFromGitHub {
+    owner = "gumyr";
+    repo = "bd_warehouse";
+    inherit rev;
+    sha256 = "sha256-ATNEYlQ410Gjaa1LDXeqWTMXTx8xucWAi/gOeBJMXbg="; #lib.fakeHash;
+  };
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ setuptools-scm ];
+  propagatedBuildInputs = [ build123d ];
+  # checkInputs = [ pytestCheckHook ];
+}

--- a/expressions/build123d.nix
+++ b/expressions/build123d.nix
@@ -17,6 +17,7 @@
   svgpathtools,
   trianglesolver,
   vtk,
+  breakpointHook, gdb,
 }: let
   pname = "build123d";
   version = "0.9.1";
@@ -25,7 +26,7 @@
     repo = pname;
     rev = "v${version}";
     deepClone = true;
-    hash = "sha256-A4XgB10QVU/zv6TXILIQ73FyZ/msb7vDss3vXAEaJiA=";
+    hash = "sha256-A3hB804paNhndYHPaosh4dwH0OwyQy9nDsM+TTwZ+mE=";
   };
 in
   buildPythonPackage {
@@ -34,13 +35,17 @@ in
 
     patchPhase = ''
       substituteInPlace pyproject.toml \
-        --replace "cadquery-ocp" "ocp"
+        --replace-fail "cadquery-ocp" "ocp" \
+        --replace-fail "ipython >= 8.0.0, < 9" "ipython >= 8.0.0, < 10"
     '';
 
     nativeBuildInputs = [
       git
       pytestCheckHook
       setuptools-scm
+
+      breakpointHook
+      gdb
     ];
 
     propagatedBuildInputs = [

--- a/expressions/cadquery.nix
+++ b/expressions/cadquery.nix
@@ -1,6 +1,8 @@
 { lib
   , buildPythonPackage
-  , setuptools_scm
+  , python
+  , setuptools
+  , setuptools-scm
   , isPy3k
   , pythonOlder
   , fetchFromGitHub
@@ -26,17 +28,22 @@ buildPythonPackage rec {
   pname = "cadquery";
   version = if (builtins.hasAttr "rev" src) then (builtins.substring 0 7 src.rev) else "local-dev";
   inherit src;
+  pyproject = true;
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = "${version}";
+  nativeBuildInputs = [ setuptools ];
 
-  nativeBuildInputs = [ setuptools_scm ];
-
+  # test suite passes with multimethod 2.0, remove constraint
   patchPhase = ''
     substituteInPlace setup.py \
-      --replace "cadquery-ocp" "ocp"
+      --replace-fail "cadquery-ocp" "ocp" \
+      --replace-fail ",<2.0" ""
   '';
 
-  propagatedBuildInputs = [
+  dependencies = [
     ocp
     ezdxf
     casadi
@@ -49,11 +56,17 @@ buildPythonPackage rec {
   ];
 
   # If the user wants extra fonts, probably have to add them here
-  FONTCONFIG_FILE = makeFontsConf {
-    fontDirectories = [ freefont_ttf ];
+  env = {
+    SETUPTOOLS_SCM_PRETEND_VERSION = "${version}";
+    FONTCONFIG_FILE = makeFontsConf {
+      fontDirectories = [ freefont_ttf ];
+    };
   };
 
   disabled = !isPy3k;
+
+  # can't find casadi for some strange reason
+  dontCheckRuntimeDeps = true;
 
   checkInputs = [
     pytestCheckHook

--- a/expressions/clang.nix
+++ b/expressions/clang.nix
@@ -28,6 +28,7 @@ let
 in buildPythonPackage rec {
   pname = "clang";
   version = llvmPackages.clang-unwrapped.version;
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "llvm";
@@ -35,6 +36,8 @@ in buildPythonPackage rec {
     rev = "llvmorg-${version}";
     sha256 = "sha256-wjuZQyXQ/jsmvy6y1aksCcEDXGBjuhpgngF3XQJ/T4s=";
   };
+
+  build-system = [ setuptools ];
 
   unpackPhase = ''
     export sourceRoot=$PWD/source

--- a/expressions/cq-editor.nix
+++ b/expressions/cq-editor.nix
@@ -11,6 +11,9 @@ mkDerivationWith python3Packages.buildPythonApplication {
   pname = "cq-editor";
   version = "local";
 
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
   # src = ./CQ-editor;
   inherit src;
 
@@ -21,9 +24,10 @@ mkDerivationWith python3Packages.buildPythonApplication {
     pyqt5
     pyparsing
     pyqtgraph
-    cq-kit
+    # cq-kit
     #broken with CQ 0.5.2: cq-warehouse
     build123d
+    bd_warehouse
     # spyder_3
     spyder
     pathpy
@@ -32,6 +36,9 @@ mkDerivationWith python3Packages.buildPythonApplication {
   ];
 
   postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "spyder>=5.5.6,<6" "spyder>=5.5.6,<=6.1" \
+      --replace-fail "qtconsole>=5.5.1,<5.6.0" "qtconsole>=5.5.1,<=5.6.1"
     # "fa." icons were removed from qtawesome
     substituteInPlace cq_editor/widgets/viewer.py \
       --replace-fail "fa.square-o" "fa5.square" \
@@ -47,8 +54,6 @@ mkDerivationWith python3Packages.buildPythonApplication {
     # spyder no longer registers run cell actions
     sed -i '/removeAction/d' cq_editor/widgets/editor.py
   '';
-
-  build-system = [ python3Packages.setuptools ];
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/expressions/cq-kit/default.nix
+++ b/expressions/cq-kit/default.nix
@@ -1,6 +1,7 @@
 {
   lib
   , buildPythonPackage
+  , setuptools
   , fetchFromGitHub
   , cadquery
   , pytestCheckHook
@@ -17,6 +18,9 @@ buildPythonPackage rec {
     sha256 = "sha256-opk2eESaZoel9Oc8UYi7DsDnMJf623twQ77DHHLzfHo=";
     fetchSubmodules = true;
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   postPatch = ''
     substituteInPlace cqkit/cq_discrete.py \

--- a/expressions/nlopt.nix
+++ b/expressions/nlopt.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "nlopt";
-  version = "2.7.1";
+  version = "2.10.0dev";
 
   src = fetchFromGitHub {
     owner = "stevengj";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-TgieCX7yUdTAEblzXY/gCN0r6F9TVDh4RdNDjQdXZ1o=";
+    rev = "a75f3d99785a3f99ecdf851c8f32718466907017"; # v${version}
+    sha256 = "sha256-lUk1h2cRlvxox5zaJHd4iHagLr2EgIaXTkAJoXsnPok=";
   };
 
   format = "other";
@@ -55,5 +55,4 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl21Plus;
     hydraPlatforms = lib.platforms.linux;
   };
-
 }

--- a/expressions/ocpsvg.nix
+++ b/expressions/ocpsvg.nix
@@ -9,6 +9,8 @@
   ocp,
   svgpathtools,
   svgelements,
+
+  breakpointHook,
 }:
 let
   pname = "ocpsvg";
@@ -21,6 +23,8 @@ in
 buildPythonPackage {
   inherit src pname version;
   pyproject = true;
+
+  nativeBuildInputs = [ breakpointHook ];
 
   patchPhase = ''
     substituteInPlace pyproject.toml \

--- a/expressions/opencascade-occt/default.nix
+++ b/expressions/opencascade-occt/default.nix
@@ -1,94 +1,38 @@
-# adapted from github:conda-forge/occt-feedstock which is the canonical cadquery source.
 {
-  stdenv
-  , lib
-  , fetchurl
-  , fetchpatch
-  , cmake
-  , ninja
-  , tcl
-  , tk
-  , libGL
-  , libGLU
-  , libXext
-  , libXmu
-  , libXi
-  , vtk
-  , xorg
-  , freetype
-  , freeimage
-  , fontconfig
-  , tbb_2021_11
-  , rapidjson
-  , glew
+ fetchpatch
+, opencascade-occt
+, tbb_2021
+, vtk
 }:
-let
-  vtk_version = lib.versions.majorMinor vtk.version;
-in
-  stdenv.mkDerivation rec {
-  pname = "opencascade-occt";
-  version = "7.8.1";
-  commit = "V${builtins.replaceStrings ["."] ["_"] version}";
 
-  src = fetchurl {
-    name = "occt-${commit}.tar.gz";
-    url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
-    sha256 = "sha256-AGMZqTLLjXbzJFW/RSTsohAGV8sMxlUmdU/Y2oOzkk8=";
-  };
-
-  nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [
-    tcl
-    tk
-    libGL
-    libGLU
-    libXext
-    libXmu
-    libXi
+opencascade-occt.overrideAttrs (o: rec {
+  buildInputs = o.buildInputs ++ [
+    tbb_2021
     vtk
-    xorg.libXt
-    freetype
-    freeimage
-    fontconfig
-    tbb_2021_11
-    rapidjson
-    glew
-  ] ++ vtk.buildInputs;
+  ];
 
-  patches = [
+  # I've removed the 3RDPARTY_DIR flag, not really sure if it's needed or not
+  cmakeFlags = o.cmakeFlags ++ [
+    # "-D BUILD_MODULE_Draw:BOOL=OFF"
+    "-D USE_TBB:BOOL=ON"
+    "-D USE_VTK:BOOL=ON"
+    "-D 3RDPARTY_VTK_LIBRARY_DIR:FILEPATH=${vtk}/lib"
+    "-D 3RDPARTY_VTK_INCLUDE_DIR:FILEPATH=${vtk}/include/vtk"
+
+    "-D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF"
+    # "-D VTK_RENDERING_BACKEND:STRING=\"OpenGL2\""
+
+    # freeimage is broken in upstream nixpkgs:
+    # https://github.com/NixOS/nixpkgs/issues/420975
+    # "-D USE_FREEIMAGE:BOOL=ON"
+  ];
+
+  patches = o.patches ++ [
     (fetchpatch {
       url = "https://raw.githubusercontent.com/conda-forge/occt-feedstock/b0960c3ec14c6213fbaef5f1c5d9d8f1d8e7c1ba/recipe/patches/blobfish.patch";
       sha256 = "sha256-wbBPJLO4amPXsIk8Nn9NQv8aypq0ndv/A7OcAfnYqfk=";
     })
-    (fetchpatch {
-      url = "https://github.com/Open-Cascade-SAS/OCCT/commit/7236e83dcc1e7284e66dc61e612154617ef715d6.patch";
-      sha256 = "sha256-NoC2mE3DG78Y0c9UWonx1vmXoU4g5XxFUT3eVXqLU60=";
-    })
   ];
 
-  # I've removed the 3RDPARTY_DIR flag, not really sure if it's needed or not
-  cmakeFlags = [
-    "-D BUILD_MODULE_Draw:BOOL=OFF"
-    "-D USE_TBB:BOOL=ON"
-    "-D BUILD_RELEASE_DISABLE_EXCEPTIONS=OFF"
-    "-D USE_VTK:BOOL=ON"
-    "-D 3RDPARTY_VTK_LIBRARY_DIR:FILEPATH=${vtk}/lib"
-    "-D 3RDPARTY_VTK_INCLUDE_DIR:FILEPATH=${vtk}/include/vtk"
-    "-D VTK_RENDERING_BACKEND:STRING=\"OpenGL2\""
-    "-D USE_FREEIMAGE:BOOL=ON"
-    "-D USE_RAPIDJSON:BOOL=ON"
-  ];
-
-  seperateDebugInfo = true;
-
-  meta = with lib; {
-    description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
-    homepage = "https://www.opencascade.org/";
-    license = licenses.lgpl21;  # essentially...
-    # The special exception defined in the file OCCT_LGPL_EXCEPTION.txt
-    # are basically about making the license a little less share-alike.
-    maintainers = with maintainers; [ marcus7070 ];
-    platforms = platforms.all;
-  };
-
-}
+  separateDebugInfo = true;
+})

--- a/expressions/py-overrides.nix
+++ b/expressions/py-overrides.nix
@@ -4,26 +4,28 @@
   , ocp-src
   , ocp-stubs-src
   , cadquery-src
-  , occt
-  , fetchFromGitHub
+  # , opencascade-occt
   , casadi
   , pybind11-stubgen-src
   , lib3mf
-}: self: super: rec {
-
-  clang = self.callPackage ./clang.nix {
-    inherit llvmPackages;
-  };
-
+  , vtk
+  , yacv-frontend
+}: self: super: let
+  vtkModule = self.toPythonModule (vtk.override {
+    python3Packages = self;
+    pythonSupport = true;
+  });
+in rec {
   pywrap = self.callPackage ./pywrap {
     inherit llvmPackages;
     src = pywrap-src;
   };
 
   ocp = self.callPackage ./OCP {
-    llvmPackages = llvmPackages;
+    inherit llvmPackages;
     src = ocp-src;
-    opencascade-occt = occt;
+    vtk = vtkModule;
+    # inherit opencascade-occt;
   };
 
   ocp-stubs = self.callPackage ./OCP/stubs.nix {
@@ -32,9 +34,12 @@
 
   cadquery = self.callPackage ./cadquery.nix {
     src = cadquery-src;
+    vtk = vtkModule;
   };
 
-  nlopt = self.callPackage ./nlopt.nix { };
+  taskipy = self.callPackage ./taskipy.nix {};
+
+  # nlopt = self.callPackage ./nlopt.nix { };
 
   pybind11-stubgen = self.callPackage ./OCP/pybind11-stubgen.nix {
     src = pybind11-stubgen-src;
@@ -52,7 +57,13 @@
 
   trianglesolver = self.callPackage ./trianglesolver.nix {};
 
-  build123d = self.callPackage ./build123d.nix {};
+  build123d = self.callPackage ./build123d.nix {
+    vtk = vtkModule;
+  };
 
-  yacv-server = self.callPackage ./yacv/server.nix {};
+  bd_warehouse = self.callPackage ./bd-warehouse.nix {};
+
+  yacv-server = self.callPackage ./yacv/server.nix {
+    inherit yacv-frontend;
+  };
 }

--- a/expressions/pywrap/default.nix
+++ b/expressions/pywrap/default.nix
@@ -3,7 +3,6 @@
   , buildPythonPackage
   , pythonOlder
   , src
-  , clang
   , pybind11
   , joblib
   , toml
@@ -21,15 +20,20 @@
   , llvmPackages
   , python
   , fetchpatch
-}:
-
-buildPythonPackage rec {
+  , setuptools
+}: let
+  pyclang = python.pkgs.libclang.override {
+    inherit llvmPackages;
+  };
+in buildPythonPackage rec {
   version = "git-" + builtins.substring 0 7 src.rev;
   pname = "pywrap";
   inherit src;
+  pyproject = true;
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
-    clang
+    pyclang
     pybind11
     joblib
     toml
@@ -44,7 +48,6 @@ buildPythonPackage rec {
     schema
     tqdm
     toposort
-    llvmPackages.libclang
   ];
 
   dontUseCmakeConfigure = true;
@@ -60,6 +63,7 @@ buildPythonPackage rec {
 
   pythonImportCheck = [ "bindgen" ];
 
+  # the nixpkgs `libclang` can't find the library path itself?
   makeWrapperArgs = [
     ''--add-flags "-l ${llvmPackages.libclang.lib}/lib/libclang.so"''
   ];

--- a/expressions/taskipy.nix
+++ b/expressions/taskipy.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # Buildtime dependencies
+  poetry-core,
+  # Runtime dependencies
+  tomli,
+  psutil,
+  mslex,
+  colorama
+}: let
+  pname = "taskipy";
+  version = "1.14.1";
+  src = fetchFromGitHub {
+    owner = "taskipy";
+    repo = "taskipy";
+    rev = version;
+    hash = "sha256-fiY0rlOmkBtrxGxXcjGcDz2JoiOHY+NyWAoF1Od+dbI=";
+  };
+in
+  buildPythonPackage {
+    inherit src pname version;
+    pyproject = true;
+
+    build-system = [
+      poetry-core
+    ];
+
+    patchPhase = ''
+      substituteInPlace pyproject.toml \
+        --replace-fail "poetry>=0.12" "poetry-core" \
+        --replace-fail "poetry.masonry.api" "poetry.core.masonry.api" \
+        --replace-fail ">=5.7.2,<7" ">=5.7.2,<8"
+    '';
+
+    dependencies = [
+      tomli
+      psutil
+      mslex
+      colorama
+    ];
+  }

--- a/expressions/yacv/frontend.nix
+++ b/expressions/yacv/frontend.nix
@@ -5,8 +5,8 @@
 }:
 let
   frontend = fetchzip {
-    url = "https://github.com/yeicor-3d/yet-another-cad-viewer/releases/download/v0.9.2/frontend.zip";
-    hash = "sha256-d5qKs9h4q9/hquVgWFb10KSE2gWTSAZQgYo9l0bzdVM=";
+    url = "https://github.com/yeicor-3d/yet-another-cad-viewer/releases/download/v0.10.10/frontend.zip";
+    hash = "sha256-+6LkNdf5+ThojdMdBBiBU2IhAw2GbWv3vVpMqjthGuI=";
   };
 in
   writeShellScriptBin "yacv-frontend" "${python3}/bin/python -m http.server --directory ${frontend}"

--- a/expressions/yacv/server.nix
+++ b/expressions/yacv/server.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildPythonPackage,
   fetchFromGitHub,
   # Buildtime dependencies
@@ -7,24 +8,26 @@
   build123d,
   pygltflib,
   pillow,
+  taskipy,
+
+  yacv-frontend,
 }: let
   pname = "yacv-server";
-  version = "0.9.2";
+  version = "0.10.10";
   src = fetchFromGitHub {
     owner = "yeicor-3d";
     repo = "yet-another-cad-viewer";
     rev = "v${version}";
-    hash = "sha256-4rNwYXjpf462zLf96QgMwPDPwoEyT5QrdUgZ7Run1fU=";
+    hash = "sha256-NELVfi9NI2ovyb5G03Z81htnyY8p6SaGtje7IQaljDM=";
   };
 in
   buildPythonPackage {
     inherit src pname version;
     pyproject = true;
 
-    SKIP_BUILD_FRONTEND = "1";
-
     build-system = [
       poetry-core
+      taskipy
     ];
 
     dependencies = [
@@ -32,4 +35,8 @@ in
       pygltflib
       pillow
     ];
+
+    preBuild = ''
+    cp -r ${yacv-frontend} frontend
+    '';
   }

--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
     "pywrap-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1736233855,
-        "narHash": "sha256-u+P/SUGpYhzA1oVbEv26DF8PBEpsotEk4iXIXZhgzHc=",
+        "lastModified": 1754377202,
+        "narHash": "sha256-HvZMrA6n0s7JBBQkV8o9h+6BAM67Tc61at2AQC3o3r0=",
         "owner": "CadQuery",
         "repo": "pywrap",
-        "rev": "9c9ca5b8aa0d9a6687394897815a682b8c319fb0",
+        "rev": "5e134c526b3bbd1758d8f63e518bc16c3d7ff352",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       flake = false;
     };
     cq-editor-src = {
-      url = "github:CadQuery/CQ-editor/0.4.0";
+      url = "github:CadQuery/CQ-editor/0.5.0";
       flake = false;
     };
     ocp-src = {
@@ -38,29 +38,38 @@
     let
       # someone else who can do the testing might want to extend this to other systems
       systems = [ "aarch64-linux" "x86_64-linux" ];
-      overlay = final: prev: {
-        # TODO: This was here but not actually referenced by anything.
-        # scotch = prev.scotch.overrideAttrs (oldAttrs: {
-        #   buildFlags = ["scotch ptscotch esmumps ptesmumps"];
-        #   installFlags = ["prefix=\${out} scotch ptscotch esmumps ptesmumps" ];
-        # } );
-        opencascade-occt = final.callPackage ./expressions/opencascade-occt { };
+      overlay = final: prev: rec {
+        # override VTK to exclude its OCCT dependency: our OCCT depends on VTK, which would cause
+        # a circular dependency in the previous configuration.
+        vtk = prev.vtk.overrideAttrs(o: {
+          buildInputs = builtins.filter (p: p.pname != "opencascade-occt") o.buildInputs;
+          cmakeFlags = o.cmakeFlags ++ [
+            (final.lib.cmakeFeature "VTK_MODULE_ENABLE_VTK_IOOCCT" "NO")
+          ];
+        });
+        opencascade-occt = final.callPackage ./expressions/opencascade-occt {
+          inherit (prev) opencascade-occt;
+        };
         lib3mf-231 = final.callPackage ./expressions/lib3mf.nix {};
         pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [(
           import expressions/py-overrides.nix {
+            # pass in the bare VTK derivation: we want to override it to our specifications to
+            # create a new VTK python module.
+            inherit yacv-frontend vtk;
             inherit (inputs) pywrap-src ocp-src ocp-stubs-src cadquery-src pybind11-stubgen-src;
-            inherit (final) fetchFromGitHub;
             # NOTE(vinszent): Latest dev env uses LLVM 15 (https://github.com/CadQuery/OCP/blob/master/environment.devenv.yml)
             llvmPackages = final.llvmPackages_15;
-            occt = final.opencascade-occt;
-            casadi = prev.casadi.override { pythonSupport=true; };
+            casadi = prev.casadi.override { pythonSupport = true; };
             lib3mf = final.lib3mf-231;
           }
         )];
         cq-editor = final.libsForQt5.callPackage ./expressions/cq-editor.nix {
           src = inputs.cq-editor-src;
         };
-        yacv-env = final.python3.withPackages (pkgs: [pkgs.yacv-server]);
+        yacv-env = final.python3.withPackages (pkgs: [
+          pkgs.yacv-server
+          pkgs.bd_warehouse
+        ]);
         yacv-frontend = final.callPackage ./expressions/yacv/frontend.nix {};
       };
     in {
@@ -77,7 +86,7 @@
         in rec {
           packages = {
             inherit (pkgs.python3.pkgs) cadquery cq-kit cq-warehouse build123d;
-            inherit (pkgs) python3 cq-editor yacv-env yacv-frontend;
+            inherit (pkgs) python3 cq-editor yacv-env yacv-frontend vtk;
             python = pkgs.python3;
           };
 


### PR DESCRIPTION
Still messy, but this seems to produce a working `build123d`. I migrated some of the in-repo derivations (`opencascade-occt`, `nlopt`) to use `overrideAttrs` on their upstream `nixpkgs` counterparts since it seems like there has been some work upstream on getting dependencies working since they were written. I'd like to try to upstream the changes necessary for those, but this will work in the interim.