### PR TITLE
fix hash for build123d

### DIFF
--- a/expressions/build123d.nix
+++ b/expressions/build123d.nix
@@ -25,7 +25,7 @@
     repo = pname;
     rev = "v${version}";
     deepClone = true;
-    hash = "sha256-A4XgB10QVU/zv6TXILIQ73FyZ/msb7vDss3vXAEaJiA=";
+    hash = "sha256-XHBli47MvaX8BNxQeBoVw3Vxp80eNi9WFSKDenw5dJE=";
   };
 in
   buildPythonPackage {


### PR DESCRIPTION
When I run `nix develop` on the current main branch, I get a hash mismatch error:

```
error: hash mismatch in fixed-output derivation '/nix/store/gxm1d4d14vb3s2pm21ga0yrqr3zbsxb1-source.drv':
         specified: sha256-A4XgB10QVU/zv6TXILIQ73FyZ/msb7vDss3vXAEaJiA=
            got:    sha256-XHBli47MvaX8BNxQeBoVw3Vxp80eNi9WFSKDenw5dJE=
error: Cannot build '/nix/store/9fcjwy5ds0mjcrsy9s8sv7dhvrygfqim-python3.12-build123d-0.9.1.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/17rsfai01a1vgyyg6lvfswg0xsp2y11c-python3.12-build123d-0.9.1-dist
         /nix/store/x92pz65vq9k4v55av12d13p890nzgda0-python3.12-build123d-0.9.1
error: Cannot build '/nix/store/6j8h6ldh40av8yhx900vda9vzrws6n2z-cq-editor-local-env.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/jgqlq3gvhp1qnqfga2whn1vbff06szpz-cq-editor-local-env-dist
         /nix/store/k8wv9a263yz3ilj9l5jg623r063wdzhi-cq-editor-local-env
```

This PR changes the hash to the suggested one. I'm curious why this issue arises though - presumably the previous hash was correct before and shouldn't change unless build123d updated the git tag to point to a new commit, which it doesn't look like they did.