### PR TITLE
cq-editor: prevent system Qt plugin paths from leaking into wrapper

### DIFF
--- a/expressions/cq-editor.nix
+++ b/expressions/cq-editor.nix
@@ -57,7 +57,11 @@ mkDerivationWith python3Packages.buildPythonApplication {
   ];
 
   # cq-editor crashes when trying to use Wayland, so force xcb
-  qtWrapperArgs = [ "--set QT_QPA_PLATFORM xcb" ];
+  qtWrapperArgs = [
+    "--set QT_QPA_PLATFORM xcb"
+    "--unset QT_PLUGIN_PATH"
+    "--unset NIXPKGS_QT5_QML_IMPORT_PATH"
+  ];
 
   postFixup = ''
     wrapQtApp "$out/bin/cq-editor"


### PR DESCRIPTION
## Summary

- Fixes the "Cannot mix incompatible Qt library (5.15.18) with this library (5.15.16)" crash at startup (#64)
- NixOS patches Qt to derive plugin search paths from  at runtime, so when the host system runs a different nixpkgs channel than the flake pins, system Qt plugins at a mismatched version get loaded alongside the flake's Qt
- Unsets  and  in the wrapper args before  re-populates them from the flake's own closure

## Test plan

- [x] Ran Warning: None of the following fonts is installed: [''] on a NixOS system with Qt 5.15.18 system-wide and confirmed cq-editor launches without the Qt version mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)